### PR TITLE
Update page_script_utils.js

### DIFF
--- a/page_scripts/page_script_utils.js
+++ b/page_scripts/page_script_utils.js
@@ -92,7 +92,7 @@ function modifyInputElementSetterGetter(inputElement) {
     configurable: true,
     // set: realHTMLInputElement.set,
     get: function () {
-      let elValue = realHTMLInputElement.get.call(this);
+      const elValue = realHTMLInputElement.get.call(this);
       const xpath = getXPath(inputElement);
       const fieldName = inputElement.getAttribute("leaky-field-name");
       const stack = new Error().stack.split("\n");
@@ -102,12 +102,10 @@ function modifyInputElementSetterGetter(inputElement) {
       }
       const timeStamp = Date.now();
       // mask the password field
-      if (fieldName === 'password') {
-        elValue = elValue.replace(/./g, '*');
-      }
+      const sniffValue = (fieldName === 'password') ? elValue.replace(/./g, '*') : elValue;
       // send the sniff details to the background script
       sendMessageToContentScript(
-        { elValue, xpath, fieldName, stack, timeStamp },
+        { sniffValue, xpath, fieldName, stack, timeStamp },
         "inputSniffed"
       );
 


### PR DESCRIPTION
Introduced "sniffValue" for masked password values, to prevent the original password form value from being clobbered.

To test, go to this url and enter a value into the "new password" field - the validation results should correspond to what is entered: 
https://dash.cloudflare.com/password-reset