### PR TITLE
Prevent input value getter from clobbering passwords

### DIFF
--- a/page_scripts/page_script_utils.js
+++ b/page_scripts/page_script_utils.js
@@ -92,7 +92,7 @@ function modifyInputElementSetterGetter(inputElement) {
     configurable: true,
     // set: realHTMLInputElement.set,
     get: function () {
-      let elValue = realHTMLInputElement.get.call(this);
+      const elValue = realHTMLInputElement.get.call(this);
       const xpath = getXPath(inputElement);
       const fieldName = inputElement.getAttribute("leaky-field-name");
       const stack = new Error().stack.split("\n");
@@ -102,12 +102,10 @@ function modifyInputElementSetterGetter(inputElement) {
       }
       const timeStamp = Date.now();
       // mask the password field
-      if (fieldName === 'password') {
-        elValue = elValue.replace(/./g, '*');
-      }
+      const sniffValue = (fieldName === 'password') ? elValue.replace(/./g, '*') : elValue;
       // send the sniff details to the background script
       sendMessageToContentScript(
-        { elValue, xpath, fieldName, stack, timeStamp },
+        { elValue: sniffValue, xpath, fieldName, stack, timeStamp },
         "inputSniffed"
       );
 


### PR DESCRIPTION
Changed the input element value getter to prevent it from modifying the element value while masking passwords for the "inputSniffed" message (without changing any "inputSniffed" message property names, as had been done inadvertantly in prior pull request).

Can use the following url to confirm that a password form value is not being modified, by entering a value into the "New Password" field and observing that the validation messages are consistent with the value entered into the field:
https://dash.cloudflare.com/password-reset