### PR TITLE
Only count distinct (domain+field) sniffs once

### DIFF
--- a/background_scripts/background.js
+++ b/background_scripts/background.js
@@ -259,7 +259,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             type: sniff.type,
           };
         }
-        const previouslySniffedDetails=sniffs[msgTabId][sniff.domain]["details"].find(d => d.inputField.fieldName===sniffDetails.fieldName && d.inputField.xpath===sniffDetails.xpath);
+        const previouslySniffedDetails = sniffs[msgTabId][sniff.domain]["details"].find(d => d.inputField.fieldName===sniffDetails.fieldName && d.inputField.xpath===sniffDetails.xpath);
         // if previously sniffed, then -update- sniff details
         if (!!previouslySniffedDetails) {
           previouslySniffedDetails.inputField.value = sniffDetails.elValue


### PR DESCRIPTION
This is a proposed behavior change to only increment the sniff count once, per distinct "sniff-domain/sniffed-field".

The change alters the "inputSniffed" message handler to -update- (rather than -insert-) sniff details, if the domain+fieldName+xpath already exists.
Included is a modification to setBadge() to display the sniff count when the badge is yellow (i.e. when there are sniffs, but no leaky requests).