### PR TITLE
fix: currentTab is undefined

### DIFF
--- a/extension_ui/js/popup.js
+++ b/extension_ui/js/popup.js
@@ -1,6 +1,13 @@
 let currentTab;
 chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
   currentTab = tabs[0];
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", function() { 
+      onDOMContentLoaded();
+    });
+  } else {
+    onDOMContentLoaded();
+  }
 });
 
 function addSliderView(tabType) {
@@ -241,7 +248,7 @@ function initializeStorage(storageId, buttonId) {
   });
 }
 
-document.addEventListener("DOMContentLoaded", function () {
+function onDOMContentLoaded() {
   renderURL(extractHostFromURL(currentTab.url));
   initializeStorage("thirdPartyControl", "sniffer-blocker-button");
   initializeStorage("requestControl", "request-blocker-button");
@@ -321,7 +328,7 @@ document.addEventListener("DOMContentLoaded", function () {
   }else if(isFirefox){
   document.getElementById('extension-body').classList.add('is-browser--moz');
   }
-});
+}
 
 function initSwitchButton() {
   const storageId = "extension_switch";


### PR DESCRIPTION
Fixes issue #15, an intermittent error that occurs when the DOMContentLoaded event handler executes before the _currentTab_ variable is initialized (within an async function).

Does this by attaching or directly calling the event handler (depending on _document.readyState_) from within the async function, after the variable has been initialized.